### PR TITLE
[L-07] Validate input tokens for user contract calls

### DIFF
--- a/src/multi/facets/Base.sol
+++ b/src/multi/facets/Base.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Store} from "../Store.sol";
+import {TokenRegLib} from "../Token.sol";
+
+/// A parent class for facets to share common utilities.
+contract BurveFacetBase {
+    /// Thrown when a token is paired with itself.
+    error SelfEdge(address);
+
+    modifier validTokens(address t0, address t1) {
+        if (t0 == t1) revert SelfEdge(t0);
+        TokenRegLib.getIdx(t0); // Will fail if its not registrered.
+        TokenRegLib.getIdx(t1);
+        _;
+    }
+
+    modifier validToken(address token) {
+        TokenRegLib.getIdx(token);
+        _;
+    }
+}

--- a/src/multi/facets/LiqFacet.sol
+++ b/src/multi/facets/LiqFacet.sol
@@ -37,6 +37,7 @@ contract LiqFacet is ReentrancyGuardTransient {
         );
 
         ClosureId cid = ClosureId.wrap(_closureId);
+        // This validates the token is registered.
         uint8 idx = TokenRegLib.getIdx(token);
         uint256 n = TokenRegLib.numVertices();
 

--- a/src/multi/facets/SwapFacet.sol
+++ b/src/multi/facets/SwapFacet.sol
@@ -4,15 +4,21 @@ pragma solidity ^0.8.27;
 import {Store} from "../Store.sol";
 import {ReentrancyGuardTransient} from "@openzeppelin/utils/ReentrancyGuardTransient.sol";
 import {Edge} from "../Edge.sol";
+import {BurveFacetBase} from "./Base.sol";
 
-contract SwapFacet is ReentrancyGuardTransient {
+contract SwapFacet is ReentrancyGuardTransient, BurveFacetBase {
     function swap(
         address recipient,
         address inToken,
         address outToken,
         int256 amountSpecified,
         uint160 sqrtPriceLimitX96
-    ) external nonReentrant returns (uint256 inAmount, uint256 outAmount) {
+    )
+        external
+        nonReentrant
+        validTokens(inToken, outToken)
+        returns (uint256 inAmount, uint256 outAmount)
+    {
         address token0;
         address token1;
         bool zeroForOne;

--- a/test/facets/Base.t.sol
+++ b/test/facets/Base.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import {BurveFacetBase} from "../../src/multi/facets/Base.sol";
+import {TokenRegistry, TokenRegLib} from "../../src/multi/Token.sol";
+import {Store} from "../../src/multi/Store.sol";
+import {MockERC20} from "../mocks/MockERC20.sol";
+
+contract BurveFacetBaseTest is Test, BurveFacetBase {
+    /* Guarded functions */
+
+    function tokenCall(address token) external validToken(token) {}
+    function tokensCall(
+        address _token0,
+        address _token1
+    ) external validTokens(_token0, _token1) {}
+
+    /* Tests */
+
+    function testValidToken() public {
+        address token0 = address(new MockERC20("0", "0", 18));
+        address token1 = address(new MockERC20("1", "1", 18));
+
+        TokenRegistry storage tokenReg = Store.tokenRegistry();
+        tokenReg.register(token0);
+        // This should be fine.
+        this.tokenCall(token0);
+        // But this hasn't been registered
+        vm.expectRevert(
+            abi.encodeWithSelector(TokenRegLib.TokenNotFound.selector, token1)
+        );
+        this.tokenCall(token1);
+    }
+
+    /// @dev Because we're reverting on ourself, the test will end prematurely so we split up this test.
+    function testInvalidTokens() public {
+        address token0 = address(new MockERC20("0", "0", 18));
+        address token1 = address(new MockERC20("1", "1", 18));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TokenRegLib.TokenNotFound.selector, token0)
+        );
+        this.tokensCall(token0, token1);
+    }
+
+    function testInvalidTokens1() public {
+        address token0 = address(new MockERC20("0", "0", 18));
+        address token1 = address(new MockERC20("1", "1", 18));
+
+        TokenRegistry storage tokenReg = Store.tokenRegistry();
+        tokenReg.register(token0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TokenRegLib.TokenNotFound.selector, token1)
+        );
+        this.tokensCall(token0, token1);
+    }
+
+    function testValidTokens() public {
+        address token0 = address(new MockERC20("0", "0", 18));
+        address token1 = address(new MockERC20("1", "1", 18));
+
+        TokenRegistry storage tokenReg = Store.tokenRegistry();
+        tokenReg.register(token0);
+        tokenReg.register(token1);
+        // No issue
+        this.tokensCall(token0, token1);
+    }
+}


### PR DESCRIPTION
This is not quite a fix to
https://github.com/PashovAuditGroup/Burve_January25_MERGED/issues/9
because it's not really a bug. They are just warning us to be careful when calling newClosureId.

However the sentiment is good and we should explicitly validate the tokens somewhere early on.