### PR TITLE
[L-04] Inclusion of test-only ViewFacet facet in production code

### DIFF
--- a/src/multi/facets/ViewFacet.sol
+++ b/src/multi/facets/ViewFacet.sol
@@ -9,8 +9,6 @@ import {VaultStorage} from "../VaultProxy.sol";
 import {SimplexStorage} from "./SimplexFacet.sol";
 import {ClosureId, newClosureId} from "../Closure.sol";
 import {TokenRegLib, TokenRegistry} from "../Token.sol";
-
-/// @notice Mock facet that exposes storage access functions for testing
 contract ViewFacet {
     function getClosureId(
         address[] memory tokens


### PR DESCRIPTION
Removing the dependent function call. The rest are just information and are useful for the frontend or other services so we should keep them. 