### PR TITLE
SherlockFix.422.remove fee asset

### DIFF
--- a/src/multi/facets/ValueFacet.sol
+++ b/src/multi/facets/ValueFacet.sol
@@ -187,11 +187,11 @@ contract ValueFacet is ReentrancyGuardTransient {
         require(bgtValue <= value, InsufficientValueForBgt(value, bgtValue));
         ClosureId cid = ClosureId.wrap(_closureId);
         Closure storage c = Store.closure(cid);
-        Store.assets().remove(msg.sender, cid, value, bgtValue);
         uint256[MAX_TOKENS] memory nominalReceives = c.removeValue(
             value,
             bgtValue
         );
+        Store.assets().remove(msg.sender, cid, value, bgtValue);
         // Send balances
         TokenRegistry storage tokenReg = Store.tokenRegistry();
         for (uint8 i = 0; i < MAX_TOKENS; ++i) {
@@ -224,12 +224,12 @@ contract ValueFacet is ReentrancyGuardTransient {
         ClosureId cid = ClosureId.wrap(_closureId);
         Closure storage c = Store.closure(cid); // Validates cid.
         VertexId vid = VertexLib.newId(token); // Validates token.
-        Store.assets().remove(msg.sender, cid, value, bgtValue);
         (uint256 removedNominal, uint256 nominalTax) = c.removeValueSingle(
             value,
             bgtValue,
             vid
         );
+        Store.assets().remove(msg.sender, cid, value, bgtValue);
         uint256 realRemoved = AdjustorLib.toReal(token, removedNominal, false);
         Store.vertex(vid).withdraw(cid, realRemoved, false);
         uint256 realTax = FullMath.mulDiv(
@@ -268,10 +268,10 @@ contract ValueFacet is ReentrancyGuardTransient {
         );
         require(valueGiven > 0, DeMinimisDeposit());
         if (maxValue > 0) require(valueGiven <= maxValue, PastSlippageBounds());
-        Store.assets().remove(msg.sender, cid, valueGiven, bgtValue);
         // Round down to avoid removing too much from the vertex.
         uint256 realTax = FullMath.mulDiv(amount, nominalTax, nominalReceive);
         Store.vertex(vid).withdraw(cid, amount + realTax, false);
+        Store.assets().remove(msg.sender, cid, valueGiven, bgtValue);
         c.addEarnings(vid, realTax);
         TransferHelper.safeTransfer(token, recipient, amount);
     }

--- a/test/facets/ValueFacet.t.sol
+++ b/test/facets/ValueFacet.t.sol
@@ -448,14 +448,25 @@ contract ValueFacetTest is MultiSetupTest {
         assertGt(bgtEarnings, 0);
         assertApproxEqAbs(bgtEarnings + earnings[1], 2 * earnings1, 2);
 
-        /// Test after removing, there are no more fees earned. Test that with query then an add and remove. As in fee claims remain unchanged.
+        /// Test after removing, there are no more fees earned.
         valueFacet.removeValue(
             address(this),
             0xA,
             uint128(valueStaked),
             uint128(bgtValueStaked)
         );
+        (collectedBalances, collectedBgt) = valueFacet.collectEarnings(
+            address(this),
+            0xA
+        );
+        assertEq(collectedBalances[1], earnings[1]);
+        assertEq(collectedBgt, bgtEarnings);
         MockERC20(tokens[1]).mint(address(vaults[1]), 1e12);
+        (, , earnings, bgtEarnings) = valueFacet.queryValue(address(this), 0xA);
+        assertEq(earnings[1], 0);
+        assertEq(bgtEarnings, 0);
+        // The first add would not earn any fees.
+        valueFacet.addValueSingle(alice, 0xA, 3e12, 1e12, tokens[1], 0);
         (, , earnings, bgtEarnings) = valueFacet.queryValue(address(this), 0xA);
         assertEq(earnings[1], 0);
         assertEq(bgtEarnings, 0);


### PR DESCRIPTION
Resolves https://audits.sherlock.xyz/contests/858/voting/422
Fees from trim balances were not getting distributed to the asset being removed.
