### PR TITLE
Use a finalize function that adds earnings and orders stake value pro…

### DIFF
--- a/src/multi/facets/SimplexFacet.sol
+++ b/src/multi/facets/SimplexFacet.sol
@@ -77,11 +77,7 @@ contract SimplexFacet {
     /// Emitted when overall simplex fees are changed..
     event SimplexFeesSet(uint128 defaultEdgeFeeX128, uint128 protocolTakeX128);
     /// Emitted when the edge fee is set.
-    event EdgeFeeSet(
-        VertexId indexed i,
-        VertexId indexed j,
-        uint128 edgeFeeX128
-    );
+    event EdgeFeeSet(uint8 indexed i, uint8 indexed j, uint128 edgeFeeX128);
 
     /* Getters */
 
@@ -418,10 +414,14 @@ contract SimplexFacet {
     function setEdgeFee(uint8 idx0, uint8 idx1, uint128 edgeFeeX128) external {
         AdminLib.validateOwner();
 
+        if (idx0 > idx1) {
+            (idx0, idx1) = (idx1, idx0);
+        }
+
         VertexId i = VertexLib.newId(idx0);
         VertexId j = VertexLib.newId(idx1);
 
         SimplexLib.setEdgeFeeX128(i, j, edgeFeeX128);
-        emit EdgeFeeSet(i, j, edgeFeeX128);
+        emit EdgeFeeSet(idx0, idx1, edgeFeeX128);
     }
 }


### PR DESCRIPTION
https://audits.sherlock.xyz/contests/858/voting/196

This is extracted from another branch already rebased on which moves fees into Edges rather than on a per closure basis so there may be strange diffs due to that. (And as a result we should not land this as its already included in the final commit for review).

But overall, the change is to move earnings and stake value changes to a finalize function so that

trim balances gives the earnings to everyone still in the pool.
the earnings are distributed properly, i.e. on add value the earnings are given first to everything still in the pool and then the value is updated. For removing value, the value needs to be removed first and then fees are given out to everyone still remaining.