### PR TITLE
Reuse the vProxy between vertex trims in setEX128

### DIFF
--- a/src/multi/closure/Closure.sol
+++ b/src/multi/closure/Closure.sol
@@ -9,6 +9,7 @@ import {AdjustorLib} from "../Adjustor.sol";
 import {ClosureId} from "./Id.sol";
 import {FullMath} from "../../FullMath.sol";
 import {ValueLib, SearchParams} from "../Value.sol";
+import {VaultProxy} from "../vertex/VaultProxy.sol";
 import {ReserveLib} from "../vertex/Reserve.sol";
 import {Store} from "../Store.sol";
 import {UnsafeMath} from "Commons/Math/UnsafeMath.sol";
@@ -742,6 +743,37 @@ library ClosureImpl {
                     (unspentShares << 128) /
                     self.bgtValueStaked;
             }
+        }
+    }
+
+    /// A special version of the trimBalance behavior that is optimized for updating balances of a vertex
+    /// across multiple closures. This means we have to dramatically reduce gas usage.
+    /// It uses one vault proxy to avoid excessive calls into the vault.
+    function massTrimBalance(
+        Closure storage self,
+        VertexId vid,
+        VaultProxy memory vProxy
+    ) internal {
+        uint8 idx = vid.idx();
+        // Roundup the balance we need.
+        uint256 realBalance = AdjustorLib.toReal(idx, self.balances[idx], true);
+        (uint256 earnings, uint256 unspentShares) = Store
+            .vertex(vid)
+            .liteTrimBalance(
+                self.cid,
+                vProxy,
+                realBalance,
+                self.valueStaked,
+                self.bgtValueStaked
+            );
+        // All pools start with non-zero nonbgtvalue
+        self.earningsPerValueX128[idx] +=
+            (earnings << 128) /
+            (self.valueStaked - self.bgtValueStaked);
+        if (self.bgtValueStaked > 0) {
+            self.unexchangedPerBgtValueX128[idx] +=
+                (unspentShares << 128) /
+                self.bgtValueStaked;
         }
     }
 

--- a/src/multi/facets/SimplexFacet.sol
+++ b/src/multi/facets/SimplexFacet.sol
@@ -188,9 +188,11 @@ contract SimplexSetFacet {
         bool concentrate = eX128 > oldEX128;
         VertexId vid = VertexLib.newId(idx);
 
+        // We'll need this for depositing more tokens or for mass trimming.
+        VaultProxy memory vProxy = VaultLib.getProxy(vid);
+
         // For deposits when not concentrating.
         uint256 needed = 0;
-        VaultProxy memory vProxy = VaultLib.getProxy(vid);
         Vertex storage v = Store.vertex(vid);
 
         // We need to make sure the value is the same before and after the change in E
@@ -213,7 +215,7 @@ contract SimplexSetFacet {
             c.balances[idx] = ValueLib.x(c.targetX128, eX128, valueX128, true);
             if (concentrate) {
                 // If we're concentrating, the balance needed is smaller so we trim.
-                c.trimBalance(vid);
+                c.massTrimBalance(vid, vProxy);
             } else {
                 // If we're expanding the range, we'll need more tokens to get the same value.
                 uint256 singleDeposit = c.balances[idx] - oldX;
@@ -232,9 +234,10 @@ contract SimplexSetFacet {
                 address(this),
                 needed
             );
-            // Commit the deposits now that we have the tokens.
-            vProxy.commit();
         }
+        // If not concentrating, commit the deposits now that we have the tokens.
+        // If concentrating, commit the trim moves to reserves.
+        vProxy.commit();
     }
 
     /// @notice Sets the adjustor.

--- a/src/multi/vertex/Vertex.sol
+++ b/src/multi/vertex/Vertex.sol
@@ -131,6 +131,45 @@ library VertexImpl {
         }
     }
 
+    /// The same functionality as the above trimBalances but without any vault commits
+    /// which also means we can't do any bgt exchanges. However this is useful for mass vertex operations
+    /// when needed such as when E is updated.
+    function liteTrimBalance(
+        Vertex storage self,
+        ClosureId cid,
+        VaultProxy memory vProxy,
+        uint256 targetReal,
+        uint256 value,
+        uint256 bgtValue
+    ) internal returns (uint256 reserveSharesEarned, uint256 unspentShares) {
+        uint256 realBalance = vProxy.balance(cid, false);
+        // We don't error and instead emit in this scenario because clearly the vault is not working properly but if
+        // we error users can't withdraw funds. Instead the right response is to lock and move vaults immediately.
+        if (targetReal > realBalance) {
+            emit InsufficientBalance(self.vid, cid, targetReal, realBalance);
+            return (0, 0);
+        }
+        uint256 residualReal = realBalance - targetReal;
+        // We don't compound when the residual is small as rounding will inflate reserve share balances.
+        if (residualReal < MIN_TRIM) {
+            return (0, 0);
+        }
+
+        // Although we won't be exchanging for bgt, we still need to calculate their portion of earnings
+        // and add it to the unspent balances.
+        uint256 bgtResidual = FullMath.mulDiv(residualReal, bgtValue, value);
+
+        // Now we do a nilpotent withdraw since we aren't actually removing any balances from the vault.
+        vProxy.nilpotentWithdraw(cid, residualReal);
+        // And just split the shares accordingly.
+        reserveSharesEarned = ReserveLib.deposit(
+            vProxy,
+            self.vid,
+            residualReal - bgtResidual
+        );
+        unspentShares = ReserveLib.deposit(vProxy, self.vid, bgtResidual);
+    }
+
     /// A few version of trim that just returns the real balances earned.
     function viewTrim(
         Vertex storage self,


### PR DESCRIPTION
This cheapens the gas cost, but in return we no longer do any bgt exchanges during the trim induced by a tighten concentration range.