### PR TITLE
Add Closer integration

### DIFF
--- a/script/DeployCloser.s.sol
+++ b/script/DeployCloser.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {Closer} from "../src/integrations/closer/Closer.sol";
+
+contract DeployCloser is Script {
+    address constant BERACHAIN_ROUTER =
+        0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7;
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        Closer closer = new Closer(BERACHAIN_ROUTER);
+        console2.log("Closer deployed at:", address(closer));
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/integrations/closer/Closer.sol
+++ b/src/integrations/closer/Closer.sol
@@ -55,8 +55,11 @@ contract Closer is ReentrancyGuardTransient {
             revert InvalidToken();
         }
 
-        // 2. Snapshot outToken balance to handle pre-existing dust.
-        uint256 outBalanceBefore = IERC20(outToken).balanceOf(address(this));
+        // 2. Snapshot all token balances to scope approvals to only what removeValue provides.
+        uint256[MAX_TOKENS] memory balancesBefore;
+        for (uint256 i = 0; i < tokens.length; i++) {
+            balancesBefore[i] = IERC20(tokens[i]).balanceOf(address(this));
+        }
 
         // 3. Transfer value position from user to this contract.
         ValueTokenFacet(pool).transferFrom(
@@ -76,21 +79,21 @@ contract Closer is ReentrancyGuardTransient {
             minAmountsReceived
         );
 
-        // 5. Swap all non-outToken balances into outToken via router.
+        // 5. Swap only the received amounts (not pre-existing balances) into outToken via router.
         for (uint256 i = 0; i < tokens.length; i++) {
             if (i == outTokenIdx) continue;
             if (txData[i].length == 0) continue;
 
-            uint256 balance = IERC20(tokens[i]).balanceOf(address(this));
-            if (balance == 0) continue;
+            uint256 received = IERC20(tokens[i]).balanceOf(address(this)) - balancesBefore[i];
+            if (received == 0) continue;
 
-            IERC20(tokens[i]).forceApprove(router, balance);
+            IERC20(tokens[i]).forceApprove(router, received);
             (bool success, ) = router.call(txData[i]);
             if (!success) revert RouterFailure();
         }
 
         // 6. Calculate totalOut, check slippage, and send to user.
-        totalOut = IERC20(outToken).balanceOf(address(this)) - outBalanceBefore;
+        totalOut = IERC20(outToken).balanceOf(address(this)) - balancesBefore[outTokenIdx];
         if (totalOut < minOutAmount) {
             revert MinOutAmountNotMet();
         }

--- a/src/integrations/closer/Closer.sol
+++ b/src/integrations/closer/Closer.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {TransferHelper} from "Commons/Util/TransferHelper.sol";
+import {IBurveMultiValue} from "../../multi/interfaces/IBurveMultiValue.sol";
+import {IBurveMultiSimplex} from "../../multi/interfaces/IBurveMultiSimplex.sol";
+import {ValueTokenFacet} from "../../multi/facets/ValueTokenFacet.sol";
+import {MAX_TOKENS} from "../../multi/Constants.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuardTransient} from "openzeppelin-contracts/utils/ReentrancyGuardTransient.sol";
+
+contract Closer is ReentrancyGuardTransient {
+    using SafeERC20 for IERC20;
+    address public immutable router;
+
+    constructor(address _router) {
+        router = _router;
+    }
+
+    error InvalidToken();
+    error RouterFailure();
+    error MinOutAmountNotMet();
+
+    /// Remove value from a closure, swap all received tokens into a single outToken, and send to the user.
+    /// @param pool The pool to remove value from.
+    /// @param outToken The token to receive after swapping.
+    /// @param closureId The closure to remove value from.
+    /// @param value The value to remove.
+    /// @param bgtValue The BGT value to remove.
+    /// @param txData The calldata to execute on the router for swapping each non-outToken.
+    /// @param minAmountsReceived Per-token minimums passed to removeValue as amountLimits.
+    /// @param minOutAmount Minimum total outToken the user must receive.
+    /// @return totalOut The total outToken sent to the user.
+    function burn(
+        address pool,
+        address outToken,
+        uint16 closureId,
+        uint128 value,
+        uint128 bgtValue,
+        bytes[MAX_TOKENS] memory txData,
+        uint256[MAX_TOKENS] calldata minAmountsReceived,
+        uint256 minOutAmount
+    ) external nonReentrant returns (uint256 totalOut) {
+        // 1. Validate outToken against pool token list.
+        address[] memory tokens = IBurveMultiSimplex(pool).getTokens();
+        uint256 outTokenIdx = MAX_TOKENS;
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (tokens[i] == outToken) {
+                outTokenIdx = i;
+                break;
+            }
+        }
+        if (outTokenIdx >= MAX_TOKENS) {
+            revert InvalidToken();
+        }
+
+        // 2. Snapshot outToken balance to handle pre-existing dust.
+        uint256 outBalanceBefore = IERC20(outToken).balanceOf(address(this));
+
+        // 3. Transfer value position from user to this contract.
+        ValueTokenFacet(pool).transferFrom(
+            msg.sender,
+            address(this),
+            closureId,
+            value,
+            bgtValue
+        );
+
+        // 4. Remove value — tokens arrive at this contract.
+        IBurveMultiValue(pool).removeValue(
+            address(this),
+            closureId,
+            value,
+            bgtValue,
+            minAmountsReceived
+        );
+
+        // 5. Swap all non-outToken balances into outToken via router.
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (i == outTokenIdx) continue;
+            if (txData[i].length == 0) continue;
+
+            uint256 balance = IERC20(tokens[i]).balanceOf(address(this));
+            if (balance == 0) continue;
+
+            IERC20(tokens[i]).forceApprove(router, balance);
+            (bool success, ) = router.call(txData[i]);
+            if (!success) revert RouterFailure();
+        }
+
+        // 6. Calculate totalOut, check slippage, and send to user.
+        totalOut = IERC20(outToken).balanceOf(address(this)) - outBalanceBefore;
+        if (totalOut < minOutAmount) {
+            revert MinOutAmountNotMet();
+        }
+        TransferHelper.safeTransfer(outToken, msg.sender, totalOut);
+    }
+}

--- a/test/integrations/closer/Closer.t.sol
+++ b/test/integrations/closer/Closer.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+import {BurveForkableTest} from "../Fork.u.sol";
+import {Closer} from "../../../src/integrations/closer/Closer.sol";
+import {MAX_TOKENS} from "../../../src/multi/Constants.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {console2} from "forge-std/console2.sol";
+import {Create2Deployer} from "../../utils/Create2Deployer.sol";
+import {IBurveMultiValue} from "../../../src/multi/interfaces/IBurveMultiValue.sol";
+import {IBurveMultiSimplex} from "../../../src/multi/interfaces/IBurveMultiSimplex.sol";
+import {ValueTokenFacet} from "../../../src/multi/facets/ValueTokenFacet.sol";
+
+contract TestCloser is BurveForkableTest {
+    Closer closer;
+    Create2Deployer create2Deployer;
+    bytes32 internal constant CLOSER_SALT = keccak256("closer-test-salt");
+
+    function deployCloserDeterministically() internal returns (Closer) {
+        if (address(create2Deployer) == address(0)) {
+            create2Deployer = new Create2Deployer();
+        }
+        bytes memory bytecode = abi.encodePacked(
+            type(Closer).creationCode,
+            abi.encode(0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7)
+        );
+        address addr = create2Deployer.deploy(bytecode, CLOSER_SALT);
+        return Closer(addr);
+    }
+
+    /// Helper: deal tokens for a closure, approve the diamond, and addValue to open a position.
+    /// @return posValue The value of the opened position.
+    function _openPosition(
+        uint16 closureId,
+        uint128 depositValue
+    ) internal returns (uint256 posValue) {
+        address[] memory poolTokens = IBurveMultiSimplex(diamond).getTokens();
+        for (uint256 i = 0; i < poolTokens.length; i++) {
+            if ((1 << i) & closureId > 0) {
+                deal(poolTokens[i], address(this), 10_000e18);
+                IERC20(poolTokens[i]).approve(diamond, type(uint256).max);
+            }
+        }
+        uint256[MAX_TOKENS] memory addLimits;
+        IBurveMultiValue(diamond).addValue(
+            address(this),
+            closureId,
+            depositValue,
+            0,
+            addLimits
+        );
+        (posValue, ) = ValueTokenFacet(diamond).balanceOf(
+            address(this),
+            closureId
+        );
+    }
+
+    /// Open a position on the live Burve stablecoin pool (closure 3 = USDC+USDT),
+    /// then close it with the Closer, receiving USDC as the outToken.
+    function testOpenAndCloseTwoToken() public forkOnly {
+        closer = deployCloserDeterministically();
+
+        address[] memory poolTokens = IBurveMultiSimplex(diamond).getTokens();
+        uint16 closureId = 3; // USDC (idx 0) + USDT (idx 1)
+        address outToken = poolTokens[0]; // USDC
+
+        // --- Open ---
+        uint256 posValue = _openPosition(closureId, 1e15);
+        console2.log("opened position value", posValue);
+        assertGt(posValue, 0, "position should exist");
+
+        // --- Approve Closer ---
+        ValueTokenFacet(diamond).approve(
+            address(closer),
+            closureId,
+            posValue,
+            0
+        );
+
+        // --- Close ---
+        // No swap txData — the outToken's proportional share from removeValue
+        // is forwarded to the user. The other token stays in the Closer.
+        // In production the txData would swap USDT->USDC via OogaBooga.
+        bytes[MAX_TOKENS] memory txData;
+        uint256[MAX_TOKENS] memory minAmountsReceived;
+
+        uint256 outBefore = IERC20(outToken).balanceOf(address(this));
+        uint256 totalOut = closer.burn(
+            diamond,
+            outToken,
+            closureId,
+            uint128(posValue),
+            0,
+            txData,
+            minAmountsReceived,
+            0
+        );
+        uint256 outAfter = IERC20(outToken).balanceOf(address(this));
+
+        // --- Assertions ---
+        assertEq(outAfter - outBefore, totalOut, "balance delta == totalOut");
+        assertGt(totalOut, 0, "should receive outToken");
+        console2.log("USDC received from close", totalOut);
+
+        // Position should be fully closed.
+        (uint256 posAfter, ) = ValueTokenFacet(diamond).balanceOf(
+            address(this),
+            closureId
+        );
+        assertEq(posAfter, 0, "position should be fully closed");
+
+        // The non-outToken (USDT) portion sits in the Closer (no swap was executed).
+        uint256 closerUsdtBalance = IERC20(poolTokens[1]).balanceOf(
+            address(closer)
+        );
+        console2.log("USDT remaining in closer", closerUsdtBalance);
+        assertGt(closerUsdtBalance, 0, "USDT should remain in closer (no swap)");
+    }
+
+    /// Same flow with a three-token closure (USDC+USDT+HONEY).
+    function testOpenAndCloseThreeToken() public forkOnly {
+        closer = deployCloserDeterministically();
+
+        address[] memory poolTokens = IBurveMultiSimplex(diamond).getTokens();
+        uint16 closureId = 7; // USDC (idx 0) + USDT (idx 1) + HONEY (idx 2)
+        address outToken = poolTokens[0]; // USDC
+
+        // --- Open ---
+        uint256 posValue = _openPosition(closureId, 1e15);
+        console2.log("opened position value", posValue);
+        assertGt(posValue, 0, "position should exist");
+
+        // --- Approve Closer ---
+        ValueTokenFacet(diamond).approve(
+            address(closer),
+            closureId,
+            posValue,
+            0
+        );
+
+        // --- Close ---
+        bytes[MAX_TOKENS] memory txData;
+        uint256[MAX_TOKENS] memory minAmountsReceived;
+
+        uint256 outBefore = IERC20(outToken).balanceOf(address(this));
+        uint256 totalOut = closer.burn(
+            diamond,
+            outToken,
+            closureId,
+            uint128(posValue),
+            0,
+            txData,
+            minAmountsReceived,
+            0
+        );
+        uint256 outAfter = IERC20(outToken).balanceOf(address(this));
+
+        // --- Assertions ---
+        assertEq(outAfter - outBefore, totalOut, "balance delta == totalOut");
+        assertGt(totalOut, 0, "should receive outToken");
+        console2.log("USDC received from close", totalOut);
+
+        (uint256 posAfter, ) = ValueTokenFacet(diamond).balanceOf(
+            address(this),
+            closureId
+        );
+        assertEq(posAfter, 0, "position should be fully closed");
+
+        // USDT and HONEY remain in the Closer (no swaps).
+        assertGt(
+            IERC20(poolTokens[1]).balanceOf(address(closer)),
+            0,
+            "USDT should remain in closer"
+        );
+        assertGt(
+            IERC20(poolTokens[2]).balanceOf(address(closer)),
+            0,
+            "HONEY should remain in closer"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the **Closer** contract (`src/integrations/closer/Closer.sol`) that allows users to remove value from a closure and swap all received tokens into a single outToken via an external router (OogaBooga)
- Includes fork tests against the live Berachain stablecoin pool (`test/integrations/closer/Closer.t.sol`)
- Adds a deploy script (`script/DeployCloser.s.sol`)
- Uses `SafeERC20.forceApprove()` instead of raw `approve()` to handle USDT-style tokens that revert on non-zero-to-non-zero allowance changes

## Test plan
- [x] `forge build` compiles cleanly
- [x] `forge test` — 354 tests pass, no regressions
- [ ] Fork tests pass with `FORK_URL` on Berachain mainnet
- [ ] Octane security report reviewed for high/critical findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)