### PR TITLE
Add Condenser: batch swap helper for collectEarnings

### DIFF
--- a/script/DeployCondenser.s.sol
+++ b/script/DeployCondenser.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {Condenser} from "../src/integrations/condenser/Condenser.sol";
+
+contract DeployCondenser is Script {
+    address constant BERACHAIN_ROUTER =
+        0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7;
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        Condenser condenser = new Condenser(BERACHAIN_ROUTER);
+        console2.log("Condenser deployed at:", address(condenser));
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/DeployCondenser.s.sol
+++ b/script/DeployCondenser.s.sol
@@ -9,6 +9,11 @@ contract DeployCondenser is Script {
     address constant BERACHAIN_ROUTER =
         0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7;
 
+    // Deployed address: 0x874Dfa2164933F802B0FfC7613CAB335Db7Ff788
+    // Chain: Berachain (80094), Block: 17262816
+    // Tx: 0x71f5e2dc5b060b18410773a4baddc41ecffa5ce1202e69df6315d1b49928ef99
+    // Verified: https://berascan.com/address/0x874dfa2164933f802b0ffc7613cab335db7ff788
+
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);

--- a/src/integrations/condenser/Condenser.sol
+++ b/src/integrations/condenser/Condenser.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {TransferHelper} from "Commons/Util/TransferHelper.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuardTransient} from "openzeppelin-contracts/utils/ReentrancyGuardTransient.sol";
+
+/// @title Condenser
+/// @notice A generalized batch swap helper. Tokens are sent to the contract first
+/// (e.g. via collectEarnings), then swapAndForward consolidates them into a single
+/// outToken via OogaBooga router calls and forwards the result to the caller.
+contract Condenser is ReentrancyGuardTransient {
+    using SafeERC20 for IERC20;
+    address public immutable router;
+
+    constructor(address _router) {
+        router = _router;
+    }
+
+    error RouterFailure();
+    error MinOutAmountNotMet();
+    error ArrayLengthMismatch();
+
+    /// Execute a batch of OogaBooga swaps, consolidating into outToken.
+    /// @param outToken The single token to receive after all swaps.
+    /// @param inTokens Array of tokens to swap (order matches txData).
+    /// @param txData Router calldata for each inToken swap. Empty = skip.
+    /// @param minOutAmount Minimum outToken the caller must receive.
+    /// @dev Intended for atomic use: send tokens to this contract and call swapAndForward
+    /// in the same transaction (or rapid succession). Do not leave tokens sitting in this contract.
+    function swapAndForward(
+        address outToken,
+        address[] calldata inTokens,
+        bytes[] calldata txData,
+        uint256 minOutAmount
+    ) external nonReentrant returns (uint256 totalOut) {
+        if (inTokens.length != txData.length) revert ArrayLengthMismatch();
+
+        uint256 outBefore = IERC20(outToken).balanceOf(address(this));
+
+        for (uint256 i = 0; i < inTokens.length; i++) {
+            if (txData[i].length == 0) continue;
+            uint256 balance = IERC20(inTokens[i]).balanceOf(address(this));
+            if (balance == 0) continue;
+
+            IERC20(inTokens[i]).forceApprove(router, balance);
+            (bool success, ) = router.call(txData[i]);
+            if (!success) revert RouterFailure();
+            // Clear any residual approval to prevent leftover router allowances.
+            IERC20(inTokens[i]).forceApprove(router, 0);
+        }
+
+        totalOut = IERC20(outToken).balanceOf(address(this)) - outBefore;
+        if (totalOut < minOutAmount) revert MinOutAmountNotMet();
+        TransferHelper.safeTransfer(outToken, msg.sender, totalOut);
+    }
+}

--- a/test/integrations/condenser/Condenser.t.sol
+++ b/test/integrations/condenser/Condenser.t.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {BurveForkableTest} from "../Fork.u.sol";
+import {Condenser} from "../../../src/integrations/condenser/Condenser.sol";
+import {MAX_TOKENS} from "../../../src/multi/Constants.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {console2} from "forge-std/console2.sol";
+import {Create2Deployer} from "../../utils/Create2Deployer.sol";
+import {IBurveMultiValue} from "../../../src/multi/interfaces/IBurveMultiValue.sol";
+import {IBurveMultiSimplex} from "../../../src/multi/interfaces/IBurveMultiSimplex.sol";
+import {ValueTokenFacet} from "../../../src/multi/facets/ValueTokenFacet.sol";
+
+contract TestCondenser is BurveForkableTest {
+    Condenser condenser;
+    Create2Deployer create2Deployer;
+    bytes32 internal constant CONDENSER_SALT =
+        keccak256("condenser-test-salt");
+
+    function deployCondenserDeterministically() internal returns (Condenser) {
+        if (address(create2Deployer) == address(0)) {
+            create2Deployer = new Create2Deployer();
+        }
+        bytes memory bytecode = abi.encodePacked(
+            type(Condenser).creationCode,
+            abi.encode(0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7)
+        );
+        address addr = create2Deployer.deploy(bytecode, CONDENSER_SALT);
+        return Condenser(addr);
+    }
+
+    /// Helper: deal tokens for a closure, approve the diamond, and addValue to open a position.
+    /// @return posValue The value of the opened position.
+    function _openPosition(
+        uint16 closureId,
+        uint128 depositValue
+    ) internal returns (uint256 posValue) {
+        address[] memory poolTokens = IBurveMultiSimplex(diamond).getTokens();
+        for (uint256 i = 0; i < poolTokens.length; i++) {
+            if ((1 << i) & closureId > 0) {
+                deal(poolTokens[i], address(this), 10_000e18);
+                IERC20(poolTokens[i]).approve(diamond, type(uint256).max);
+            }
+        }
+        uint256[MAX_TOKENS] memory addLimits;
+        IBurveMultiValue(diamond).addValue(
+            address(this),
+            closureId,
+            depositValue,
+            0,
+            addLimits
+        );
+        (posValue, ) = ValueTokenFacet(diamond).balanceOf(
+            address(this),
+            closureId
+        );
+    }
+
+    /// Open a position on the live Burve stablecoin pool (closure 3 = USDC+USDT),
+    /// collect earnings to the Condenser, then call swapAndForward to consolidate into USDC.
+    function testSwapAndForwardTwoToken() public forkOnly {
+        condenser = deployCondenserDeterministically();
+
+        address[] memory poolTokens = IBurveMultiSimplex(diamond).getTokens();
+        uint16 closureId = 3; // USDC (idx 0) + USDT (idx 1)
+        address outToken = poolTokens[0]; // USDC
+
+        // --- Open position ---
+        uint256 posValue = _openPosition(closureId, 1e15);
+        console2.log("opened position value", posValue);
+        assertGt(posValue, 0, "position should exist");
+
+        // --- Collect earnings to Condenser ---
+        IBurveMultiValue(diamond).collectEarnings(
+            address(condenser),
+            closureId
+        );
+
+        // --- swapAndForward ---
+        // No router txData — the outToken's portion from collectEarnings flows through.
+        // Non-outToken stays in the condenser (in production OogaBooga txData would swap it).
+        address[] memory inTokens = new address[](1);
+        inTokens[0] = poolTokens[1]; // USDT
+        bytes[] memory txData = new bytes[](1);
+        // empty txData[0] — skip USDT swap
+
+        uint256 outBefore = IERC20(outToken).balanceOf(address(this));
+        uint256 totalOut = condenser.swapAndForward(
+            outToken,
+            inTokens,
+            txData,
+            0
+        );
+        uint256 outAfter = IERC20(outToken).balanceOf(address(this));
+
+        // --- Assertions ---
+        assertEq(outAfter - outBefore, totalOut, "balance delta == totalOut");
+        console2.log("USDC received from swapAndForward", totalOut);
+
+        // Position should still exist (we only collected earnings, not removed value).
+        (uint256 posAfter, ) = ValueTokenFacet(diamond).balanceOf(
+            address(this),
+            closureId
+        );
+        assertEq(posAfter, posValue, "position should remain intact");
+    }
+
+    /// Same flow with a three-token closure (USDC+USDT+HONEY).
+    function testSwapAndForwardThreeToken() public forkOnly {
+        condenser = deployCondenserDeterministically();
+
+        address[] memory poolTokens = IBurveMultiSimplex(diamond).getTokens();
+        uint16 closureId = 7; // USDC (idx 0) + USDT (idx 1) + HONEY (idx 2)
+        address outToken = poolTokens[0]; // USDC
+
+        // --- Open position ---
+        uint256 posValue = _openPosition(closureId, 1e15);
+        console2.log("opened position value", posValue);
+        assertGt(posValue, 0, "position should exist");
+
+        // --- Collect earnings to Condenser ---
+        IBurveMultiValue(diamond).collectEarnings(
+            address(condenser),
+            closureId
+        );
+
+        // --- swapAndForward ---
+        address[] memory inTokens = new address[](2);
+        inTokens[0] = poolTokens[1]; // USDT
+        inTokens[1] = poolTokens[2]; // HONEY
+        bytes[] memory txData = new bytes[](2);
+        // empty txData — skip all swaps
+
+        uint256 outBefore = IERC20(outToken).balanceOf(address(this));
+        uint256 totalOut = condenser.swapAndForward(
+            outToken,
+            inTokens,
+            txData,
+            0
+        );
+        uint256 outAfter = IERC20(outToken).balanceOf(address(this));
+
+        // --- Assertions ---
+        assertEq(outAfter - outBefore, totalOut, "balance delta == totalOut");
+        console2.log("USDC received from swapAndForward", totalOut);
+
+        (uint256 posAfter, ) = ValueTokenFacet(diamond).balanceOf(
+            address(this),
+            closureId
+        );
+        assertEq(posAfter, posValue, "position should remain intact");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Condenser` contract — a generalized batch swap helper that consolidates multiple tokens into a single outToken via OogaBooga router calls
- Tokens are sent to the contract first (e.g. via `collectEarnings`), then `swapAndForward` executes router swaps and forwards the result to the caller
- Includes deploy script with verification support and fork tests

## Security
- Residual router approvals cleared after each swap
- Array length validation on `inTokens`/`txData`
- `ReentrancyGuardTransient` protection
- Slippage protection via `minOutAmount`

## Deploy
```bash
DEPLOYER_PRIVATE_KEY=<key> ETHERSCAN_API_KEY=<key> forge script script/DeployCondenser.s.sol --rpc-url https://rpc.berachain.com --broadcast --verify
```

## Test plan
- [ ] `forge build` compiles cleanly
- [ ] Fork tests pass with active Berachain fork
- [ ] Deploy + verify on testnet before mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)