### PR TITLE
Add BatchValueFacet for single-event multi-token deposits

### DIFF
--- a/src/integrations/opener/Opener.sol
+++ b/src/integrations/opener/Opener.sol
@@ -153,21 +153,35 @@ contract Opener is RFTPayer, Auto165, ReentrancyGuardTransient {
             amountLimits
         );
 
-        // Single deposit any remaining amounts of each token
-        for (uint256 i = 0; i < tokens.length; i++) {
-            uint128 balance = SafeCast.toUint128(IERC20(tokens[i]).balanceOf(address(this)));
-            uint256 spend = myBalances[i] - balance;
-            // If for some reason we have a large residual of any token, that means the prices were moved
-            // out of proportion from our expectations, potentially from a malicious actor.
-            if (spend < minSpend[i]) {
-                revert AmountSlippageExceeded();
+        // Batch deposit any remaining amounts of each token (single AddValue event)
+        {
+            uint256 batchCount;
+            for (uint256 i = 0; i < tokens.length; i++) {
+                uint128 balance = SafeCast.toUint128(IERC20(tokens[i]).balanceOf(address(this)));
+                uint256 spend = myBalances[i] - balance;
+                if (spend < minSpend[i]) {
+                    revert AmountSlippageExceeded();
+                }
+                if (balance > 0) batchCount++;
             }
-            if (balance > 0) {
-                addedValue += IBurveMultiValue(pool).addSingleForValue(
+
+            if (batchCount > 0) {
+                address[] memory batchTokens = new address[](batchCount);
+                uint128[] memory batchAmounts = new uint128[](batchCount);
+                uint256 idx;
+                for (uint256 i = 0; i < tokens.length; i++) {
+                    uint128 balance = SafeCast.toUint128(IERC20(tokens[i]).balanceOf(address(this)));
+                    if (balance > 0) {
+                        batchTokens[idx] = tokens[i];
+                        batchAmounts[idx] = balance;
+                        idx++;
+                    }
+                }
+                addedValue += IBurveMultiValue(pool).addBatchSingleForValue(
                     msg.sender,
                     closureId,
-                    tokens[i],
-                    balance,
+                    batchTokens,
+                    batchAmounts,
                     bgtPercentX256,
                     0
                 );

--- a/src/multi/Diamond.sol
+++ b/src/multi/Diamond.sol
@@ -34,7 +34,7 @@ contract SimplexDiamond is IDiamond {
         AdminLib.initOwner(msg.sender);
         SimplexLib.init(name, symbol, facets.adjustor, 0, 0);
 
-        FacetCut[] memory cuts = new FacetCut[](15);
+        FacetCut[] memory cuts = new FacetCut[](16);
 
         {
             bytes4[] memory cutFunctionSelectors = new bytes4[](1);
@@ -248,6 +248,19 @@ contract SimplexDiamond is IDiamond {
                 facetAddress: facets.valueTokenFacet,
                 action: IDiamond.FacetCutAction.Add,
                 functionSelectors: selectors
+            });
+        }
+
+        {
+            bytes4[] memory batchSelectors = new bytes4[](1);
+            batchSelectors[0] = IBurveMultiValue
+                .addBatchSingleForValue
+                .selector;
+
+            cuts[15] = FacetCut({
+                facetAddress: facets.batchValueFacet,
+                action: FacetCutAction.Add,
+                functionSelectors: batchSelectors
             });
         }
 

--- a/src/multi/InitLib.sol
+++ b/src/multi/InitLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.27;
 
 import {ValueFacet, ValueSingleFacet} from "./facets/ValueFacet.sol";
 import {AddTokenValueFacet, RemoveTokenValueFacet, QueryValueFacet} from "./facets/ValueFacet.sol";
+import {BatchValueFacet} from "./facets/BatchValueFacet.sol";
 import {ValueTokenFacet} from "./facets/ValueTokenFacet.sol";
 import {SimplexAdminFacet, SimplexSetFacet, SimplexGetFacet} from "./facets/SimplexFacet.sol";
 import {SwapFacet} from "./facets/SwapFacet.sol";
@@ -16,6 +17,7 @@ struct BurveFacets {
     address addTokenValueFacet;
     address removeTokenValueFacet;
     address queryValueFacet;
+    address batchValueFacet;
     // Simplex facets
     address simplexAdminFacet;
     address simplexSetFacet;
@@ -37,6 +39,7 @@ library InitLib {
         facets.addTokenValueFacet = address(new AddTokenValueFacet());
         facets.removeTokenValueFacet = address(new RemoveTokenValueFacet());
         facets.queryValueFacet = address(new QueryValueFacet());
+        facets.batchValueFacet = address(new BatchValueFacet());
 
         facets.simplexAdminFacet = address(new SimplexAdminFacet());
         facets.simplexSetFacet = address(new SimplexSetFacet());

--- a/src/multi/facets/BatchValueFacet.sol
+++ b/src/multi/facets/BatchValueFacet.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {SafeCast} from "Commons/Math/Cast.sol";
+import {RFTLib} from "Commons/Util/RFT.sol";
+import {ReentrancyGuardTransient} from "openzeppelin-contracts/utils/ReentrancyGuardTransient.sol";
+import {ClosureId} from "../closure/Id.sol";
+import {Closure} from "../closure/Closure.sol";
+import {VertexId, VertexLib} from "../vertex/Id.sol";
+import {Store} from "../Store.sol";
+import {AdjustorLib} from "../Adjustor.sol";
+import {SearchParams} from "../Value.sol";
+import {FullMath} from "../../FullMath.sol";
+import {IBurveMultiEvents} from "../interfaces/IBurveMultiEvents.sol";
+import {ValueErrors} from "./ValueFacet.sol";
+
+/// @title BatchValueFacet
+/// @notice Batch deposit of multiple tokens into a closure, emitting a single AddValue event.
+///         This replaces the pattern of calling addSingleForValue() N times (once per token),
+///         which emitted N separate AddValue events per logical deposit.
+contract BatchValueFacet is ReentrancyGuardTransient {
+    error LengthMismatch();
+    error EmptyBatch();
+
+    /// @notice Deposit multiple tokens into a closure in a single call.
+    ///         Processes each token sequentially (order matters as each deposit changes closure state),
+    ///         but emits only one aggregated AddValue event.
+    /// @param recipient The address that receives the value position.
+    /// @param _closureId The closure to deposit into.
+    /// @param tokens Array of token addresses to deposit.
+    /// @param amounts Array of token amounts to deposit (must match tokens length).
+    /// @param bgtPercentX256 The percentage of value to designate as BGT value (X256 fixed-point).
+    /// @param minTotalValue Revert if total value received is less than this.
+    /// @return totalValueReceived The total value added to the closure.
+    function addBatchSingleForValue(
+        address recipient,
+        uint16 _closureId,
+        address[] calldata tokens,
+        uint128[] calldata amounts,
+        uint256 bgtPercentX256,
+        uint128 minTotalValue
+    ) external nonReentrant returns (uint256 totalValueReceived) {
+        if (tokens.length != amounts.length) revert LengthMismatch();
+        if (tokens.length == 0) revert EmptyBatch();
+
+        ClosureId cid = ClosureId.wrap(_closureId);
+        Closure storage c = Store.closure(cid);
+        SearchParams memory search = Store.simplex().searchParams;
+
+        uint256 totalBgtValue;
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (amounts[i] == 0) continue;
+            (uint256 valueReceived, uint256 bgtValue) = _depositToken(
+                c, cid, _closureId, tokens[i], amounts[i], bgtPercentX256, search
+            );
+            totalValueReceived += valueReceived;
+            totalBgtValue += bgtValue;
+        }
+
+        require(
+            totalValueReceived >= minTotalValue,
+            ValueErrors.PastSlippageBounds()
+        );
+
+        Store.assets().add(recipient, cid, totalValueReceived, totalBgtValue);
+
+        // Single aggregated event for the entire batch deposit
+        emit IBurveMultiEvents.AddValue(
+            recipient,
+            _closureId,
+            totalValueReceived
+        );
+    }
+
+    /// @dev Process a single token deposit within the batch. Separated to avoid stack-too-deep.
+    function _depositToken(
+        Closure storage c,
+        ClosureId cid,
+        uint16 _closureId,
+        address token,
+        uint128 amount,
+        uint256 bgtPercentX256,
+        SearchParams memory search
+    ) private returns (uint256 valueReceived, uint256 bgtValue) {
+        VertexId vid = VertexLib.newId(token);
+
+        // Transfer token from sender via RFT
+        {
+            address[] memory t = new address[](1);
+            int256[] memory d = new int256[](1);
+            t[0] = token;
+            d[0] = SafeCast.toInt256(amount);
+            RFTLib.settle(msg.sender, t, d, "");
+        }
+
+        // Process deposit
+        uint256 nominalIn = AdjustorLib.toNominal(token, amount, false);
+        uint256 nominalTax;
+        (valueReceived, nominalTax) = c.addTokenForValue(
+            vid,
+            nominalIn,
+            search
+        );
+        require(valueReceived > 0, ValueErrors.DeMinimisDeposit());
+
+        uint256 realTax = FullMath.mulDiv(amount, nominalTax, nominalIn);
+        bgtValue = FullMath.mulX256(bgtPercentX256, valueReceived, true);
+
+        emit IBurveMultiEvents.ClosureFeesEarned(
+            _closureId,
+            vid.idx(),
+            nominalTax,
+            realTax
+        );
+        c.finalize(
+            vid,
+            realTax,
+            int256(uint256(valueReceived)),
+            int256(uint256(bgtValue))
+        );
+        Store.vertex(vid).deposit(cid, amount - realTax);
+    }
+}

--- a/src/multi/interfaces/IBurveMultiValue.sol
+++ b/src/multi/interfaces/IBurveMultiValue.sol
@@ -52,6 +52,17 @@ interface IBurveMultiValue {
         uint128 minValue
     ) external returns (uint256 valueReceived);
 
+    /// Add exact amounts of multiple tokens to add value to a given closure in a single call.
+    /// Emits a single AddValue event instead of one per token.
+    function addBatchSingleForValue(
+        address recipient,
+        uint16 _closureId,
+        address[] calldata tokens,
+        uint128[] calldata amounts,
+        uint256 bgtPercentX256,
+        uint128 minTotalValue
+    ) external returns (uint256 totalValueReceived);
+
     /// Remove an exact amount of a single token to remove value from a given closure.
     function removeSingleForValue(
         address recipient,


### PR DESCRIPTION
## Summary
- Adds `BatchValueFacet` with `addBatchSingleForValue()` — deposits multiple tokens into a closure in a single call, emitting one aggregated `AddValue` event instead of N per-token events
- Updates `Opener.mint()` to use the batch function for residual token deposits, reducing event noise for indexers
- Registers the new facet in the diamond constructor (cut 15) and `InitLib`

## Problem
The Opener calls `addSingleForValue()` once per token when depositing residual balances after the pro-rata `addValue()` call. For closure 511 (9 active tokens), this emits up to 9 separate `AddValue` events per logical deposit. Indexers (Ponder middleware) were overcounting inflows by N× due to this event duplication.

## Diamond Cut
For the live diamond, this facet can be added via `diamondCut()` with action `Add` for the `addBatchSingleForValue` selector pointing to the deployed `BatchValueFacet` address.

## Test plan
- [x] `forge build` — compiles cleanly
- [x] `forge test` — 354 pass, 3 pre-existing failures (fork-dependent tests unrelated to this change)
- [ ] Deploy BatchValueFacet and execute diamond cut on testnet
- [ ] Redeploy Opener with batch call and verify single AddValue event per deposit

🤖 Generated with [Claude Code](https://claude.com/claude-code)