### PR TITLE
Fix ERC4626 vault share rounding vulnerability (V-001)

### DIFF
--- a/V-001.md
+++ b/V-001.md
@@ -1,0 +1,37 @@
+erc4626 vault withdrawal burns too few shares, enabling vault draining when share price increases
+The ERC4626 vault wrapper rounds down sharesToRemove on withdrawals, which can become zero for non-zero asset withdrawals once totalAssets > totalShares; this lets an attacker withdraw assets without reducing their closure’s accounting shares and progressively drain vault assets belonging to other closures/users.
+
+Affected Locations
+
+…/facets/SwapFacet.sol
+L25-135
+SwapFacet.swap() withdraws real tokens from a vertex via Store.vertex(outVid).withdraw(cid, outAmount, true) before settling transfers. This is a reachable public path to trigger vault withdrawals for arbitrary small outAmount (e.g., exact-out swaps via amountSpecified < 0).
+
+…/vertex/Vertex.sol
+L221-233
+VertexImpl.withdraw() obtains a VaultProxy and forwards the withdrawal to vProxy.withdraw(cid, amount) followed by vProxy.commit(), so any accounting bug in the vault layer directly impacts user-facing swaps/removals.
+
+…/vertex/VaultProxy.sol
+L187-213
+VaultProxyImpl.withdraw() determines the available amount using self.active.balance(cid, false) and queues the withdrawal(s) against the underlying vault pointer(s).
+
+…/vertex/VaultPointer.sol
+L48-61
+VaultPointerImpl.withdraw() dispatches to the ERC4626 wrapper with getE4626(self).withdraw(self.temp, cid, amount).
+
+…/vertex/E4626.sol
+L146-170
+VaultE4626Impl.withdraw() computes sharesToRemove = FullMath.mulDiv(self.totalShares, amount, totalAssets) which rounds down. When the ERC4626 vault has accrued yield such that totalAssets > totalShares (share price > 1 in this wrapper’s units), withdrawing a small positive amount can result in sharesToRemove == 0, so self.shares[cid] and self.totalShares are unchanged while temp.vars[2] += amount still withdraws assets on commit. This lets the caller repeatedly withdraw assets without burning proportional shares, stealing value from other closures/users sharing the same vault.
+
+Impact
+A malicious user can drain the pool’s underlying ERC20 assets held in ERC4626 vaults by repeatedly triggering small withdrawals (e.g., via exact-out swaps) that burn zero (or too few) internal shares. Because the wrapper’s per-closure share accounting no longer tracks proportional ownership, the attacker can progressively extract assets that should belong to other closures and liquidity providers, ultimately causing insolvency and preventing honest users from withdrawing/switching assets.
+
+Proof of concept
+One concrete exploit pattern once the vault has yield (totalAssets > totalShares):
+
+Ensure you have any non-zero shares[cid] in a target closure (e.g., add minimal value / liquidity so the closure owns some balance in that vertex).
+Perform a large number of exact-out operations that withdraw outAmount = 1 (or any amount < totalAssets / totalShares), such as calling SwapFacet.swap() with amountSpecified = -1 for the target outToken.
+Each withdrawal computes sharesToRemove = floor(totalShares \* 1 / totalAssets) = 0, so the closure’s internal shares do not decrease while real assets leave the vault.
+Repeating this shrinks totalAssets without shrinking the attacker’s shares[cid], allowing repeated withdrawals that cumulatively approach draining the vault’s full assets (geometric-series drain), at the expense of other users’ balances.
+Remediation
+In VaultE4626Impl.withdraw() use rounding up for share burns (e.g., FullMath.mulDivRoundingUp(self.totalShares, amount, totalAssets)) so any positive asset withdrawal burns at least the proportional amount of internal shares. Also consider enforcing sharesToRemove > 0 when amount > 0 (or increasing internal share precision) to prevent zero-share withdrawals, and add unit/invariant tests ensuring sum(balance(cid)) is conserved across deposits/withdrawals and that repeated small withdrawals cannot extract more assets than the shares burned.

--- a/src/multi/vertex/E4626.sol
+++ b/src/multi/vertex/E4626.sol
@@ -159,11 +159,11 @@ library VaultE4626Impl {
         // We don't check if we have enough assets for this cid to supply because
         // 1. The shares will underflow if we don't
         // 2. The outer check in vertex should suffice.
-        uint256 sharesToRemove = FullMath.mulDiv(
+        uint256 sharesToRemove = FullMath.mulDivRoundingUp(
             self.totalShares,
             amount,
             totalAssets
-        ); // Rounds down so someone can't repeatedly remove 1 wei and 1 share and inflate value of remaining shares.
+        ); // Rounds up so withdrawers can never extract more value than they burn in shares.
         self.shares[cid] -= sharesToRemove;
         self.totalShares -= sharesToRemove;
         temp.vars[2] += amount;

--- a/test/multi/E4626.t.sol
+++ b/test/multi/E4626.t.sol
@@ -97,6 +97,50 @@ contract E4626Test is Test {
         assertEq(vault.totalVaultShares, 0);
     }
 
+    function testWithdrawAfterYieldAccrual() public {
+        ClosureId cid1 = ClosureId.wrap(1);
+        ClosureId cid2 = ClosureId.wrap(2);
+
+        // 1. Two closures each deposit 100e18 tokens
+        {
+            VaultTemp memory temp;
+            vault.fetch(temp);
+            vault.deposit(temp, cid1, 100e18);
+            vault.deposit(temp, cid2, 100e18);
+            vault.commit(temp);
+        }
+
+        uint256 sharesBefore1 = vault.shares[cid1];
+        uint256 sharesBefore2 = vault.shares[cid2];
+        uint256 totalSharesBefore = vault.totalShares;
+        assertGt(totalSharesBefore, 0);
+
+        // 2. Simulate yield: mint 100e18 extra tokens to the ERC4626 vault
+        //    This makes totalAssets = 300e18 while totalShares stays the same
+        //    (share price goes from 1.0 to 1.5)
+        MockERC20(address(token)).mint(address(e4626), 100e18);
+
+        // 3. Withdraw 1 wei from cid1 — at least 1 share must be burned
+        {
+            VaultTemp memory temp;
+            vault.fetch(temp);
+            vault.withdraw(temp, cid1, 1);
+            vault.commit(temp);
+        }
+        uint256 sharesAfter1 = vault.shares[cid1];
+        assertLt(sharesAfter1, sharesBefore1, "At least 1 share should be burned for 1 wei withdrawal");
+
+        // 4. Withdraw 1 wei 10 times from cid2 — at least 10 shares burned total
+        for (uint256 i = 0; i < 10; i++) {
+            VaultTemp memory temp;
+            vault.fetch(temp);
+            vault.withdraw(temp, cid2, 1);
+            vault.commit(temp);
+        }
+        uint256 sharesAfter2 = vault.shares[cid2];
+        assertLe(sharesAfter2, sharesBefore2 - 10, "At least 10 shares should be burned for 10x 1-wei withdrawals");
+    }
+
     function testMultipleDeposits() public {
         ClosureId cid1 = ClosureId.wrap(1);
         ClosureId cid2 = ClosureId.wrap(2);


### PR DESCRIPTION
## Summary
- **Fix**: Round up `sharesToRemove` in `VaultE4626Impl.withdraw()` using `FullMath.mulDivRoundingUp` instead of `FullMath.mulDiv`
- **Vulnerability**: When the underlying ERC4626 vault has accrued yield (`totalAssets > totalShares`), small withdrawals produce `sharesToRemove == 0`, allowing repeated free asset extraction without burning any shares
- **Test**: Added `testWithdrawAfterYieldAccrual()` that reproduces the bug (confirmed failing before fix, passing after)

## Test plan
- [x] Test reproduces the vulnerability (fails without fix)
- [x] All 5 E4626 tests pass after fix
- [x] Full test suite: 355 pass, 0 regressions (3 pre-existing fork failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)